### PR TITLE
Handle extras for subscription confirmation

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -240,10 +240,9 @@ final GoRouter router = GoRouter(
     ),
     GoRoute(
       path: '/subscription-confirmed',
-      builder: (context, state) {
-        final data = state.extra as Map<String, dynamic>? ?? {};
-        return SubscriptionConfirmedScreen(structureInfo: data);
-      },
+      builder: (context, state) => SubscriptionConfirmedScreen(
+        structureInfo: state.extra as Map<String, dynamic>,
+      ),
     ),
     GoRoute(path: '/admin', builder: (context, state) => const AdminScreen()),
     // Ajout de la route pour l'écran de tarification

--- a/lib/screens/subscription_confirmed_screen.dart
+++ b/lib/screens/subscription_confirmed_screen.dart
@@ -11,6 +11,14 @@ class SubscriptionConfirmedScreen extends StatefulWidget {
     required this.structureInfo,
   }) : super(key: key);
 
+  /// Crée une instance depuis les extras de navigation
+  static SubscriptionConfirmedScreen fromRouteExtras(BuildContext context) {
+    final extras =
+        GoRouter.of(context).routerDelegate.currentConfiguration?.extra;
+    return SubscriptionConfirmedScreen(
+        structureInfo: (extras ?? {}) as Map<String, dynamic>);
+  }
+
   @override
   _SubscriptionConfirmedScreenState createState() =>
       _SubscriptionConfirmedScreenState();

--- a/lib/screens/subscription_upgrade_screen.dart
+++ b/lib/screens/subscription_upgrade_screen.dart
@@ -85,6 +85,10 @@ class _SubscriptionUpgradeScreenState extends State<SubscriptionUpgradeScreen> {
   void _handlePurchaseUpdate(List<PurchaseDetails> purchaseDetailsList) {
     for (final PurchaseDetails purchase in purchaseDetailsList) {
       print('🛒 Mise à jour achat: ${purchase.productID} - ${purchase.status}');
+      // 🔎 Logs détaillés pour TestFlight
+      print('🧾 Produit sélectionné : ${purchase.productID}');
+      print('🔐 Status : ${purchase.status}');
+      print('⏳ pendingCompletePurchase : ${purchase.pendingCompletePurchase}');
 
       switch (purchase.status) {
         case PurchaseStatus.purchased:


### PR DESCRIPTION
## Summary
- read `GoRouter` extras in `SubscriptionConfirmedScreen`
- update route for subscription confirmation
- add detailed logs during purchase updates

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6878b3e69888832e9ca452b96f715616