### PR TITLE
Set app label

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -11,7 +11,7 @@
     <uses-permission android:name="com.android.vending.BILLING" />
 
     <application
-        android:label="votre_app_name"
+        android:label="@string/app_name"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="app_name">Poppin's</string>
+</resources>


### PR DESCRIPTION
## Summary
- update `AndroidManifest.xml` to use a string resource for the application label
- define `app_name` string resource

## Testing
- `gradle -p android assembleDebug` *(fails: `/workspace/Poppin-s_New/android/local.properties (No such file or directory)`)*

------
https://chatgpt.com/codex/tasks/task_e_6878b8385ae0832e97779f6f5af0e154