### PR TITLE
Update in_app_purchase version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,7 +43,7 @@ dependencies:
   build_runner: ^2.4.6
   
   # 🛒 IN-APP PURCHASE - Version mise à jour pour les abonnements
-  in_app_purchase: ^3.1.11
+  in_app_purchase: ^3.2.1
   
   # 🔥 BADGES - Versions compatibles
   # 🔥 SOLUTION TEMPORAIRE : Utilise seulement app_badge_plus pour Android


### PR DESCRIPTION
## Summary
- bump `in_app_purchase` to `^3.2.1`
- ran `flutter pub get` with Flutter 3.32.1; no lockfile changes were required

## Testing
- `flutter pub get`

------
https://chatgpt.com/codex/tasks/task_e_6878b9101e00832e84f43ff649459640