### PR TITLE
Update Firebase iOS bundle id

### DIFF
--- a/lib/firebase_options.dart
+++ b/lib/firebase_options.dart
@@ -64,7 +64,7 @@ class DefaultFirebaseOptions {
     projectId: 'poppin-s-app',
     storageBucket: 'poppin-s-app.firebasestorage.app',
     iosClientId: '402812477660-m78fj12if3c9639k6vtlosq1agrg5liv.apps.googleusercontent.com',
-    iosBundleId: 'com.example.poppinsApp',
+    iosBundleId: 'com.beylet.poppinsApp',
   );
 
   static const FirebaseOptions macos = FirebaseOptions(
@@ -74,7 +74,7 @@ class DefaultFirebaseOptions {
     projectId: 'poppin-s-app',
     storageBucket: 'poppin-s-app.firebasestorage.app',
     iosClientId: '402812477660-m78fj12if3c9639k6vtlosq1agrg5liv.apps.googleusercontent.com',
-    iosBundleId: 'com.example.poppinsApp',
+    iosBundleId: 'com.beylet.poppinsApp',
   );
 
   static const FirebaseOptions windows = FirebaseOptions(


### PR DESCRIPTION
## Summary
- fix the iOS bundle id in `firebase_options.dart`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6878c8a50754832eb1ff2f4184cdefc5