### PR TITLE
Handle inactive lifecycle state without marking app_killed

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -128,8 +128,13 @@ class _PoppinsAppState extends State<PoppinsApp> with WidgetsBindingObserver {
           print("📱 App mise en arrière-plan");
           break;
 
-        case AppLifecycleState.detached:
         case AppLifecycleState.inactive:
+          // App temporairement inactive (ex: bouton Home)
+          await prefs.setBool('app_killed', false);
+          print("⏸️ App temporairement inactive");
+          break;
+
+        case AppLifecycleState.detached:
           // App fermée complètement
           await prefs.setBool('app_killed', true);
           print("❌ App fermée complètement");


### PR DESCRIPTION
## Summary
- Avoid marking `app_killed` as true when the app becomes inactive
- Only set `app_killed` to true for terminal lifecycle states (detached)

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa262dda7c832eb8af23745bc62853