### PR TITLE
Centralize sign-out session cleanup

### DIFF
--- a/lib/screens/account_deletion_screen.dart
+++ b/lib/screens/account_deletion_screen.dart
@@ -4,6 +4,7 @@ import 'package:go_router/go_router.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_storage/firebase_storage.dart';
+import '../utils/session_util.dart';
 
 class AccountDeletionScreen extends StatefulWidget {
   const AccountDeletionScreen({Key? key}) : super(key: key);
@@ -623,7 +624,7 @@ class _AccountDeletionScreenState extends State<AccountDeletionScreen> {
                 Navigator.of(context).pop();
 
                 // Déconnecter l'utilisateur
-                await FirebaseAuth.instance.signOut();
+                await SessionUtil.signOut();
 
                 // Rediriger vers login
                 context.go('/login');

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -7,6 +7,7 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:poppins_app/screens/child_profile_details_screen.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../services/subscription_service.dart';
+import '../utils/session_util.dart';
 
 class HomeScreen extends StatefulWidget {
   @override
@@ -84,7 +85,7 @@ class _HomeScreenState extends State<HomeScreen> {
       await prefs.remove('lastSessionTime');
 
       // Déconnexion Firebase
-      await FirebaseAuth.instance.signOut();
+      await SessionUtil.signOut();
 
       // Redirection vers l'écran de connexion
       if (mounted) {

--- a/lib/screens/parent_home_screen.dart
+++ b/lib/screens/parent_home_screen.dart
@@ -10,6 +10,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/badged_icon.dart';
 import '../utils/stock_badge_util.dart';
 import '../utils/message_badge_util.dart';
+import '../utils/session_util.dart';
 import 'package:http/http.dart' as http;
 import 'package:gal/gal.dart';
 import 'package:share_plus/share_plus.dart';
@@ -1804,7 +1805,7 @@ class _ParentHomeScreenState extends State<ParentHomeScreen>
                         IconButton(
                           icon: Icon(Icons.logout, color: Colors.white),
                           onPressed: () async {
-                            await _auth.signOut();
+                            await SessionUtil.signOut();
                             context.go('/');
                           },
                         ),

--- a/lib/screens/parent_settings_screen.dart
+++ b/lib/screens/parent_settings_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:go_router/go_router.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import '../utils/session_util.dart';
 
 class ParentSettingsScreen extends StatefulWidget {
   const ParentSettingsScreen({Key? key}) : super(key: key);
@@ -54,7 +55,7 @@ class _ParentSettingsScreenState extends State<ParentSettingsScreen> {
   }
   
   Future<void> _logout() async {
-    await _auth.signOut();
+    await SessionUtil.signOut();
     context.go('/login');
   }
   

--- a/lib/screens/parent_stock_screen.dart
+++ b/lib/screens/parent_stock_screen.dart
@@ -8,6 +8,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import '../widgets/badged_icon.dart';
 import '../utils/message_badge_util.dart';
 import '../utils/stock_badge_util.dart';
+import '../utils/session_util.dart';
 
 class ParentStockScreen extends StatefulWidget {
   const ParentStockScreen({Key? key}) : super(key: key);
@@ -436,7 +437,7 @@ class _ParentStockScreenState extends State<ParentStockScreen>
                         IconButton(
                           icon: Icon(Icons.logout, color: Colors.white),
                           onPressed: () async {
-                            await _auth.signOut();
+                            await SessionUtil.signOut();
                             context.go('/');
                           },
                         ),

--- a/lib/utils/session_util.dart
+++ b/lib/utils/session_util.dart
@@ -1,0 +1,11 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class SessionUtil {
+  static Future<void> signOut() async {
+    await FirebaseAuth.instance.signOut();
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool('is_logged_in', false);
+    await prefs.remove('last_login_date');
+  }
+}


### PR DESCRIPTION
## Summary
- Add SessionUtil to handle Firebase sign-out and clear login preferences.
- Replace direct signOut calls across screens with centralized SessionUtil.signOut for consistent session cleanup.

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa27caf508832e80aa9f483d8e85dc