### PR TITLE
Allow signed numeric input for temperature fields

### DIFF
--- a/lib/screens/freezer_temperature_screen.dart
+++ b/lib/screens/freezer_temperature_screen.dart
@@ -562,8 +562,8 @@ class _FreezerTemperatureScreenState extends State<FreezerTemperatureScreen> {
                               label: "Température (°C)",
                               icon: Icons.kitchen,
                               maxWidth: maxWidth,
-                              keyboardType: TextInputType.numberWithOptions(
-                                  decimal: true),
+                              keyboardType:
+                                  TextInputType.numberWithOptions(decimal: true, signed: true),
                               suffixText: "°C",
                             ),
 
@@ -968,7 +968,8 @@ class _FreezerTemperatureScreenState extends State<FreezerTemperatureScreen> {
                   controller: _temperatureController,
                   label: "Température (°C)",
                   icon: Icons.kitchen,
-                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                  keyboardType: TextInputType.numberWithOptions(
+                      decimal: true, signed: true),
                   suffixText: "°C",
                 ),
                 SizedBox(height: 24),

--- a/lib/screens/fridge_temperature_screen.dart
+++ b/lib/screens/fridge_temperature_screen.dart
@@ -346,8 +346,8 @@ class _FridgeTemperatureScreenState extends State<FridgeTemperatureScreen> {
                               label: "Température (°C)",
                               icon: Icons.thermostat,
                               maxWidth: maxWidth,
-                              keyboardType: TextInputType.numberWithOptions(
-                                  decimal: true),
+                              keyboardType:
+                                  TextInputType.numberWithOptions(decimal: true, signed: true),
                               suffixText: "°C",
                             ),
 
@@ -755,7 +755,8 @@ class _FridgeTemperatureScreenState extends State<FridgeTemperatureScreen> {
                   controller: _temperatureController,
                   label: "Température (°C)",
                   icon: Icons.thermostat,
-                  keyboardType: TextInputType.numberWithOptions(decimal: true),
+                  keyboardType: TextInputType.numberWithOptions(
+                      decimal: true, signed: true),
                   suffixText: "°C",
                 ),
                 SizedBox(height: 24),


### PR DESCRIPTION
## Summary
- Accept signed decimal input in fridge temperature entry (tablet and phone)
- Accept signed decimal input in freezer temperature entry (tablet and phone)

## Testing
- `flutter analyze lib/screens/fridge_temperature_screen.dart lib/screens/freezer_temperature_screen.dart` *(command not found: flutter)*
- `flutter test` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_68aafa84ce08832eac70460e90cb8d53