### PR TITLE
Fix error text in test photo screen

### DIFF
--- a/lib/screens/test_photo_screen.dart
+++ b/lib/screens/test_photo_screen.dart
@@ -27,7 +27,7 @@ class TestPhotoScreen extends StatelessWidget {
                   Icon(Icons.error, color: Colors.red, size: 40),
                   SizedBox(height: 8),
                   Text(
-                    'Erreur de chargement',
+                    'Erreurs de chargement',
                     style: TextStyle(color: Colors.red),
                   ),
                 ],


### PR DESCRIPTION
## Summary
- correct typo in `TestPhotoScreen` error message

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac57544508832e964ed91228f937fa