### PR TITLE
Normalize structure type in product ID lookup

### DIFF
--- a/lib/services/android_subscription_service.dart
+++ b/lib/services/android_subscription_service.dart
@@ -302,7 +302,8 @@ class AndroidSubscriptionService {
 
   /// Retourne l'ID produit Android
   static String getProductId(String structureType, int mamMembersCount) {
-    switch (structureType) {
+    final normalizedType = structureType.toLowerCase();
+    switch (normalizedType) {
       case 'assistante_maternelle':
         return _androidProductIds['assistante_maternelle']!;
       case 'mam':

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -53,7 +53,8 @@ class SubscriptionService {
   }
 
   static String getProductId(String structureType, int memberCount) {
-    if (structureType == 'MAM') {
+    final normalizedType = structureType.toLowerCase();
+    if (normalizedType == 'mam') {
       return productIds['mam_${memberCount}_members'] ??
           productIds['mam_2_members']!;
     }

--- a/lib/services/unified_subscription_service.dart
+++ b/lib/services/unified_subscription_service.dart
@@ -439,7 +439,7 @@ class UnifiedSubscriptionService {
 
   /// Retourne l'ID produit selon la plateforme et le plan
   String _getProductId(SubscriptionPlan plan) {
-    final structureType = _planToStructureType(plan);
+    final structureType = _planToStructureType(plan).toLowerCase();
     final memberCount = _planToMemberCount(plan);
 
     if (Platform.isIOS) {


### PR DESCRIPTION
## Summary
- ensure Android subscription product lookup is case-insensitive
- pass normalized structure type to platform-specific services
- make top-level subscription service handle structure type case-insensitively

## Testing
- `dart test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aef7fb5bb8832ebce244a8c6dd0c4c