### PR TITLE
refactor: centralize purchase stream handling

### DIFF
--- a/lib/services/android_subscription_service.dart
+++ b/lib/services/android_subscription_service.dart
@@ -30,7 +30,6 @@ class AndroidSubscriptionService {
 
   // État
   bool _isInitialized = false;
-  StreamSubscription<List<PurchaseDetails>>? _subscription;
   List<ProductDetails> _availableProducts = [];
 
   // 🔧 CORRIGÉ : IDs des produits Android (Google Play) - CORRESPONDENT À GOOGLE PLAY CONSOLE
@@ -58,16 +57,6 @@ class AndroidSubscriptionService {
       if (!isAvailable) {
         throw Exception('Google Play Store n\'est pas disponible');
       }
-
-      // Écouter les mises à jour d'achat
-      _subscription = _inAppPurchase.purchaseStream.listen(
-        _handlePurchaseUpdates,
-        onDone: () => print('🤖 Stream d\'achat Android fermé'),
-        onError: (error) {
-          print('❌ Erreur stream Android: $error');
-          _errorController.add('Erreur de stream: $error');
-        },
-      );
 
       // Charger les produits disponibles
       await _loadProducts();
@@ -106,13 +95,6 @@ class AndroidSubscriptionService {
       print('❌ Erreur de chargement des produits: $e');
       _errorController.add('Erreur de chargement: $e');
       rethrow;
-    }
-  }
-
-  /// Gère les mises à jour d'achat
-  void _handlePurchaseUpdates(List<PurchaseDetails> purchaseDetailsList) {
-    for (final purchase in purchaseDetailsList) {
-      _handlePurchase(purchase);
     }
   }
 
@@ -163,6 +145,9 @@ class AndroidSubscriptionService {
         break;
     }
   }
+
+  /// Expose le traitement d'un achat pour le service unifié
+  Future<void> handlePurchase(PurchaseDetails purchase) => _handlePurchase(purchase);
 
   /// Vérifie un achat (validation côté serveur recommandée)
   Future<void> _verifyPurchase(PurchaseDetails purchase) async {
@@ -400,7 +385,6 @@ class AndroidSubscriptionService {
 
   /// Nettoie les ressources
   void dispose() {
-    _subscription?.cancel();
     _subscriptionController.close();
     _errorController.close();
     _isInitialized = false;

--- a/lib/services/ios_subscription_service.dart
+++ b/lib/services/ios_subscription_service.dart
@@ -30,7 +30,6 @@ class iOSSubscriptionService {
 
   // État
   bool _isInitialized = false;
-  StreamSubscription<List<PurchaseDetails>>? _subscription;
   List<ProductDetails> _availableProducts = [];
 
   // IDs des produits iOS (App Store)
@@ -59,16 +58,6 @@ class iOSSubscriptionService {
       if (!isAvailable) {
         throw Exception('App Store n\'est pas disponible');
       }
-
-      // Écouter les mises à jour d'achat
-      _subscription = _inAppPurchase.purchaseStream.listen(
-        _handlePurchaseUpdates,
-        onDone: () => print('🍎 Stream d\'achat iOS fermé'),
-        onError: (error) {
-          print('❌ Erreur stream iOS: $error');
-          _errorController.add('Erreur de stream: $error');
-        },
-      );
 
       // Charger les produits disponibles
       await _loadProducts();
@@ -107,13 +96,6 @@ class iOSSubscriptionService {
       print('❌ Erreur de chargement des produits: $e');
       _errorController.add('Erreur de chargement: $e');
       rethrow;
-    }
-  }
-
-  /// Gère les mises à jour d'achat
-  void _handlePurchaseUpdates(List<PurchaseDetails> purchaseDetailsList) {
-    for (final purchase in purchaseDetailsList) {
-      _handlePurchase(purchase);
     }
   }
 
@@ -161,6 +143,9 @@ class iOSSubscriptionService {
         break;
     }
   }
+
+  /// Expose le traitement d'un achat pour le service unifié
+  Future<void> handlePurchase(PurchaseDetails purchase) => _handlePurchase(purchase);
 
   /// Vérifie un achat (validation côté serveur recommandée)
   Future<void> _verifyPurchase(PurchaseDetails purchase) async {
@@ -446,7 +431,6 @@ class iOSSubscriptionService {
 
   /// Nettoie les ressources
   void dispose() {
-    _subscription?.cancel();
     _subscriptionController.close();
     _errorController.close();
     _isInitialized = false;

--- a/lib/services/subscription_service.dart
+++ b/lib/services/subscription_service.dart
@@ -5,6 +5,7 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'dart:io';
 import 'dart:async';
+import 'unified_subscription_service.dart';
 
 class SubscriptionService {
   static bool get _isProduction {
@@ -102,13 +103,15 @@ class SubscriptionService {
       }
 
       // 🔧 CORRIGÉ : Utiliser la nouvelle API
-      await inAppPurchase.restorePurchases();
+      final unifiedService = UnifiedSubscriptionService.instance;
+      await unifiedService.initialize();
+      await unifiedService.restorePurchases();
 
       // Écouter le stream des achats pour vérifier
       final completer = Completer<bool>();
       late StreamSubscription subscription;
 
-      subscription = inAppPurchase.purchaseStream.listen((purchaseDetailsList) {
+      subscription = unifiedService.purchaseUpdates.listen((purchaseDetailsList) {
         bool hasActiveSubscription = false;
 
         for (PurchaseDetails purchase in purchaseDetailsList) {
@@ -342,10 +345,11 @@ class SubscriptionService {
   static Future<void> handlePurchaseUpdates() async {
     if (!_isProduction) return;
 
-    final InAppPurchase inAppPurchase = InAppPurchase.instance;
+    final unifiedService = UnifiedSubscriptionService.instance;
+    await unifiedService.initialize();
 
-    // Écouter les mises à jour d'achat
-    _subscription = inAppPurchase.purchaseStream
+    // Écouter les mises à jour d'achat via le service unifié
+    _subscription = unifiedService.purchaseUpdates
         .listen((List<PurchaseDetails> purchaseDetailsList) {
       _handlePurchaseUpdates(purchaseDetailsList);
     });
@@ -453,15 +457,16 @@ class SubscriptionService {
 
       final InAppPurchase inAppPurchase = InAppPurchase.instance;
 
-      // 🔧 CORRIGÉ : Utiliser la nouvelle API sans attendre de réponse
-      await inAppPurchase.restorePurchases();
+      final unifiedService = UnifiedSubscriptionService.instance;
+      await unifiedService.initialize();
+      await unifiedService.restorePurchases();
 
       // Écouter le stream pour capturer les achats restaurés
       final completer = Completer<bool>();
       late StreamSubscription subscription;
       bool hasActiveSubscription = false;
 
-      subscription = inAppPurchase.purchaseStream.listen((purchaseDetailsList) {
+      subscription = unifiedService.purchaseUpdates.listen((purchaseDetailsList) {
         for (PurchaseDetails purchase in purchaseDetailsList) {
           if (productIds.values.contains(purchase.productID)) {
             if (purchase.status == PurchaseStatus.purchased ||

--- a/lib/services/unified_subscription_service.dart
+++ b/lib/services/unified_subscription_service.dart
@@ -60,14 +60,18 @@ class UnifiedSubscriptionService {
       StreamController<SubscriptionInfo>.broadcast();
   final StreamController<String> _errorController =
       StreamController<String>.broadcast();
+  final StreamController<List<PurchaseDetails>> _purchaseController =
+      StreamController<List<PurchaseDetails>>.broadcast();
 
   // Streams publics
   Stream<SubscriptionInfo> get subscriptionUpdates =>
       _subscriptionController.stream;
   Stream<String> get errors => _errorController.stream;
+  Stream<List<PurchaseDetails>> get purchaseUpdates =>
+      _purchaseController.stream;
 
   bool _isInitialized = false;
-  StreamSubscription<PurchaseDetails>? _platformSubscription;
+  StreamSubscription<List<PurchaseDetails>>? _purchaseSubscription;
 
   // ✅ PROTECTION ANTI-DUPLICATION : Suivi des transactions traitées
   final Set<String> _processedTransactions = {};
@@ -90,17 +94,6 @@ class UnifiedSubscriptionService {
         _iOSService = iOSSubscriptionService.instance;
         await _iOSService!.initialize();
 
-        // ✅ ÉCOUTE PROTÉGÉE des événements iOS
-        _platformSubscription = _iOSService!.subscriptionUpdates.listen(
-          (purchase) {
-            _handlePurchaseUpdate(purchase);
-          },
-          onError: (error) {
-            print('❌ Erreur iOS dans le stream: $error');
-            _errorController.add('iOS Error: $error');
-          },
-        );
-
         _iOSService!.errors.listen(
           (error) {
             print('❌ Erreur iOS: $error');
@@ -112,17 +105,6 @@ class UnifiedSubscriptionService {
         _androidService = AndroidSubscriptionService.instance;
         await _androidService!.initialize();
 
-        // ✅ ÉCOUTE PROTÉGÉE des événements Android
-        _platformSubscription = _androidService!.subscriptionUpdates.listen(
-          (purchase) {
-            _handlePurchaseUpdate(purchase);
-          },
-          onError: (error) {
-            print('❌ Erreur Android dans le stream: $error');
-            _errorController.add('Android Error: $error');
-          },
-        );
-
         _androidService!.errors.listen(
           (error) {
             print('❌ Erreur Android: $error');
@@ -133,6 +115,25 @@ class UnifiedSubscriptionService {
         throw UnsupportedError(
             'Plateforme non supportée: ${Platform.operatingSystem}');
       }
+
+      // Écoute centralisée des achats
+      _purchaseSubscription =
+          InAppPurchase.instance.purchaseStream.listen((purchases) {
+        for (final purchase in purchases) {
+          if (Platform.isIOS) {
+            _iOSService?.handlePurchase(purchase);
+          } else if (Platform.isAndroid) {
+            _androidService?.handlePurchase(purchase);
+          }
+          _handlePurchaseUpdate(purchase);
+        }
+        _purchaseController.add(purchases);
+      }, onError: (error) {
+        print('❌ Erreur dans le stream d\'achat: $error');
+        _errorController.add('Stream Error: $error');
+      }, onDone: () {
+        print('Stream d\'achat fermé');
+      });
 
       _isInitialized = true;
       print(
@@ -487,9 +488,10 @@ class UnifiedSubscriptionService {
   void dispose() {
     try {
       _debounceTimer?.cancel();
-      _platformSubscription?.cancel();
+      _purchaseSubscription?.cancel();
       _subscriptionController.close();
       _errorController.close();
+      _purchaseController.close();
       _iOSService?.dispose();
       _androidService?.dispose();
       _processedTransactions.clear();


### PR DESCRIPTION
## Summary
- centralize InAppPurchase purchase stream in UnifiedSubscriptionService
- remove platform-specific purchase stream listeners and expose handlePurchase methods
- update SubscriptionService to consume centralized purchase updates

## Testing
- `flutter --version` *(fails: command not found)*
- `apt-get install -y dart` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68aef94866a4832ea6d9389057d822a7