### PR TITLE
Support additional subscription product IDs

### DIFF
--- a/lib/services/unified_subscription_service.dart
+++ b/lib/services/unified_subscription_service.dart
@@ -313,10 +313,20 @@ class UnifiedSubscriptionService {
 
   /// ✅ AMÉLIORATION : Formatage des prix avec € et /mois
   String _getPriceFromProductId(String productId) {
-    if (productId.contains('assistante_maternelle')) return '12,99 € / mois';
-    if (productId.contains('mam_2_members')) return '24,99 € / mois';
-    if (productId.contains('mam_3_members')) return '34,99 € / mois';
-    if (productId.contains('mam_4_members')) return '44,99 € / mois';
+    final id = productId.toLowerCase();
+
+    if (id.contains('assistante_maternelle') || id.contains('assmat')) {
+      return '12,99 € / mois';
+    }
+    if (id.contains('mam_2_members') || id.contains('mam2')) {
+      return '24,99 € / mois';
+    }
+    if (id.contains('mam_3_members') || id.contains('mam3')) {
+      return '34,99 € / mois';
+    }
+    if (id.contains('mam_4_members') || id.contains('mam4')) {
+      return '44,99 € / mois';
+    }
     return 'Prix inconnu';
   }
 


### PR DESCRIPTION
## Summary
- handle `assmat`, `mam2`, `mam3`, and `mam4` product IDs when deriving prices

## Testing
- `/tmp/flutter/bin/flutter pub get`
- `/tmp/flutter/bin/flutter test` *(fails: Test directory "test" not found)*
- `/tmp/flutter/bin/flutter analyze` *(warning: 1501 issues found)*
- `/tmp/flutter/bin/flutter build apk` *(fails: No Android SDK found)*

------
https://chatgpt.com/codex/tasks/task_e_68aefac38c24832e883ec386fcec8ff3