### PR TITLE
Refactor Android purchase flow to use GooglePlayProductDetails

### DIFF
--- a/lib/services/android_subscription_service.dart
+++ b/lib/services/android_subscription_service.dart
@@ -323,12 +323,18 @@ class AndroidSubscriptionService {
         orElse: () => throw Exception('Produit non trouvé: $productId'),
       );
 
+      // Convertit en produit Google Play et vérifie qu'il s'agit d'un abonnement
+      final GooglePlayProductDetails gpProduct =
+          product as GooglePlayProductDetails;
+      if (gpProduct.subscriptionOffers.isEmpty) {
+        throw Exception('Produit non abonnement: $productId');
+      }
+
       final GooglePlayPurchaseParam purchaseParam = GooglePlayPurchaseParam(
-        productDetails: product,
-        offerToken: product.subscriptionOffers.first.offerToken,
+        productDetails: gpProduct,
+        offerToken: gpProduct.subscriptionOffers.first.offerToken,
       );
 
-      // Pour les abonnements, buyNonConsumable est utilisé
       final bool success = await _inAppPurchase.buyNonConsumable(
         purchaseParam: purchaseParam,
       );


### PR DESCRIPTION
## Summary
- Cast ProductDetails to GooglePlayProductDetails and ensure subscription offers exist
- Build GooglePlayPurchaseParam with offer token and trigger purchase via buyNonConsumable

## Testing
- `dart format lib/services/android_subscription_service.dart` (fails: command not found)
- `apt-get install -y dart` (fails: Unable to locate package dart)


------
https://chatgpt.com/codex/tasks/task_e_68af02f461ec832e9ef45b607b0f2b7f