### PR TITLE
Use billing API prices for subscriptions

### DIFF
--- a/lib/screens/pricing_screen.dart
+++ b/lib/screens/pricing_screen.dart
@@ -1,6 +1,5 @@
 // lib/screens/pricing_screen.dart
 import 'package:flutter/material.dart';
-import 'package:flutter/foundation.dart';
 import 'dart:io';
 import 'package:go_router/go_router.dart';
 // Import du nouveau service unifié
@@ -309,16 +308,12 @@ class _PricingScreenState extends State<PricingScreen> {
 
     final String structureType = isAssMat ? 'assistante_maternelle' : 'MAM';
     final int memberCount = isAssMat ? 1 : _selectedMamMembers;
-    final double priceAmount = isAssMat
-        ? 12.99
-        : (_selectedMamMembers == 2
-            ? 24.99
-            : (_selectedMamMembers == 3 ? 34.99 : 44.99));
-    final String priceDisplay = isAssMat
-        ? '12,99 € / mois'
-        : (_selectedMamMembers == 2
-            ? '24,99 € / mois'
-            : (_selectedMamMembers == 3 ? '34,99 € / mois' : '44,99 € / mois'));
+    final product =
+        _subscriptionService.getProductDetailsForPlan(_getCurrentPlan());
+    final double priceAmount = product?.rawPrice ?? 0.0;
+    final String priceDisplay =
+        product != null ? '${product.price} / mois' : 'Prix inconnu';
+    final String currency = product?.currencyCode ?? 'EUR';
 
     context.go('/subscription-confirmed', extra: {
       'structureType': structureType,
@@ -326,7 +321,7 @@ class _PricingScreenState extends State<PricingScreen> {
       'memberCount': memberCount,
       'priceAmount': priceAmount,
       'priceDisplay': priceDisplay,
-      'currency': 'EUR',
+      'currency': currency,
       'billingPeriod': 'monthly',
     });
   }
@@ -365,20 +360,9 @@ class _PricingScreenState extends State<PricingScreen> {
 
   /// Retourne le prix selon le type
   String _getPrice() {
-    if (widget.structureType == 'assistante_maternelle') {
-      return '12,99€';
-    } else {
-      switch (_selectedMamMembers) {
-        case 2:
-          return '24,99€';
-        case 3:
-          return '34,99€';
-        case 4:
-          return '44,99€';
-        default:
-          return '24,99€';
-      }
-    }
+    final plan = _getCurrentPlan();
+    final price = _subscriptionService.getPriceForPlan(plan);
+    return price ?? 'N/A';
   }
 
   /// Retourne la description des fonctionnalités
@@ -397,16 +381,21 @@ class _PricingScreenState extends State<PricingScreen> {
 
   /// Retourne le prix pour un nombre de membres donné
   String _getPriceForMembers(int members) {
+    SubscriptionPlan plan;
     switch (members) {
       case 2:
-        return '24,99€';
+        plan = SubscriptionPlan.mam2Members;
+        break;
       case 3:
-        return '34,99€';
+        plan = SubscriptionPlan.mam3Members;
+        break;
       case 4:
-        return '44,99€';
+        plan = SubscriptionPlan.mam4Members;
+        break;
       default:
-        return '24,99€';
+        plan = SubscriptionPlan.mam2Members;
     }
+    return _subscriptionService.getPriceForPlan(plan) ?? 'N/A';
   }
 
   @override
@@ -587,7 +576,7 @@ class _PricingScreenState extends State<PricingScreen> {
                                             ),
                                             const SizedBox(height: 4),
                                             Text(
-                                              _getPriceForMembers(members),
+                                              '${_getPriceForMembers(members)} / mois',
                                               style: TextStyle(
                                                 fontSize: 14,
                                                 fontWeight: FontWeight.w600,

--- a/lib/services/unified_subscription_service.dart
+++ b/lib/services/unified_subscription_service.dart
@@ -77,6 +77,9 @@ class UnifiedSubscriptionService {
   Timer? _debounceTimer;
   static const Duration _debounceDelay = Duration(milliseconds: 500);
 
+  // Cache des détails produits pour accéder aux prix localisés
+  final Map<String, ProductDetails> _productDetailsCache = {};
+
   /// Initialise le service selon la plateforme
   Future<void> initialize() async {
     if (_isInitialized) {
@@ -271,9 +274,11 @@ class UnifiedSubscriptionService {
 
   /// Mappe les données de PurchaseDetails vers SubscriptionInfo
   SubscriptionInfo _mapPurchaseToSubscription(PurchaseDetails purchase) {
+    final cachedPrice =
+        _productDetailsCache[purchase.productID]?.price ?? 'Prix inconnu';
     return SubscriptionInfo(
       productId: purchase.productID,
-      localizedPrice: _getPriceFromProductId(purchase.productID),
+      localizedPrice: cachedPrice,
       status: _mapPurchaseStatus(purchase.status),
       purchaseDate: DateTime.now(), // TODO: extraire la vraie date d'achat
       expiryDate: _calculateExpiryDate(purchase.productID),
@@ -310,15 +315,6 @@ class UnifiedSubscriptionService {
     return true;
   }
 
-  /// ✅ AMÉLIORATION : Formatage des prix avec € et /mois
-  String _getPriceFromProductId(String productId) {
-    if (productId.contains('assistante_maternelle')) return '12,99 € / mois';
-    if (productId.contains('mam_2_members')) return '24,99 € / mois';
-    if (productId.contains('mam_3_members')) return '34,99 € / mois';
-    if (productId.contains('mam_4_members')) return '44,99 € / mois';
-    return 'Prix inconnu';
-  }
-
   /// Récupère les produits disponibles
   Future<List<SubscriptionInfo>> getAvailableSubscriptions() async {
     await _ensureInitialized();
@@ -330,6 +326,11 @@ class UnifiedSubscriptionService {
         products = await _iOSService!.getAvailableProducts();
       } else if (Platform.isAndroid) {
         products = await _androidService!.getAvailableProducts();
+      }
+
+      // Mettre en cache les détails produits pour un accès ultérieur
+      for (final product in products) {
+        _productDetailsCache[product.id] = product;
       }
 
       return products
@@ -344,6 +345,30 @@ class UnifiedSubscriptionService {
       _errorController.add('Erreur de récupération: $e');
       return [];
     }
+  }
+
+  /// Récupère le prix localisé pour un plan donné à partir du cache
+  String? getPriceForPlan(SubscriptionPlan plan) {
+    final productId = _getProductIdForPlan(plan);
+    return _productDetailsCache[productId]?.price;
+  }
+
+  /// Récupère les détails complets du produit pour un plan
+  ProductDetails? getProductDetailsForPlan(SubscriptionPlan plan) {
+    final productId = _getProductIdForPlan(plan);
+    return _productDetailsCache[productId];
+  }
+
+  String _getProductIdForPlan(SubscriptionPlan plan) {
+    final structureType = _planToStructureType(plan);
+    final memberCount = _planToMemberCount(plan);
+    if (Platform.isIOS) {
+      return iOSSubscriptionService.getProductId(structureType, memberCount);
+    } else if (Platform.isAndroid) {
+      final androidType = structureType == 'mam' ? 'MAM' : structureType;
+      return AndroidSubscriptionService.getProductId(androidType, memberCount);
+    }
+    return '';
   }
 
   /// ✅ AMÉLIORATION : Achète un abonnement avec protection et timeout


### PR DESCRIPTION
## Summary
- remove hard-coded price mapping and cache product prices from billing API
- expose helpers to get cached prices for plans
- show dynamic prices on pricing screen and during purchase confirmation

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b17d78d758832eaf1061e573da205d