### PR TITLE
Add MAM group chat screen with route and dashboard link

### DIFF
--- a/lib/routes.dart
+++ b/lib/routes.dart
@@ -658,6 +658,44 @@ final GoRouter router = GoRouter(
       builder: (context, state) => const CleaningScheduleScreen(),
     ),
     GoRoute(
+      path: '/mam/messages',
+      builder: (context, state) {
+        return FutureBuilder<String>(
+          future: _getStructureId(),
+          builder: (context, snapshot) {
+            if (snapshot.connectionState != ConnectionState.done) {
+              return const Scaffold(
+                body: Center(child: CircularProgressIndicator()),
+              );
+            }
+
+            if (snapshot.hasError) {
+              return Scaffold(
+                body: Center(
+                  child: Text(
+                    "Erreur lors du chargement de la structure: ${snapshot.error}",
+                  ),
+                ),
+              );
+            }
+
+            final mamId = snapshot.data ?? '';
+            if (mamId.isEmpty) {
+              return const Scaffold(
+                body: Center(
+                  child: Text(
+                    "Aucune structure MAM trouvée pour cet utilisateur",
+                  ),
+                ),
+              );
+            }
+
+            return MamGroupChatScreen(mamId: mamId);
+          },
+        );
+      },
+    ),
+    GoRoute(
       path: '/parent/messages',
       builder: (context, state) => const ParentMessagesScreen(),
     ),
@@ -813,28 +851,3 @@ String? _handleRedirect(BuildContext context, GoRouterState state) {
   print("✅ Utilisateur connecté ou route autorisée: $path");
   return null;
 }
-    // Messagerie interne MAM
-    GoRoute(
-      path: '/mam/chat',
-      builder: (context, state) {
-        return FutureBuilder<String>(
-          future: _getStructureId(),
-          builder: (context, snapshot) {
-            if (!snapshot.hasData) {
-              return const Scaffold(
-                body: Center(child: CircularProgressIndicator()),
-              );
-            }
-            final structureId = snapshot.data ?? '';
-            if (structureId.isEmpty) {
-              return const Scaffold(
-                body: Center(
-                  child: Text('Aucune structure MAM trouvée pour cet utilisateur'),
-                ),
-              );
-            }
-            return MamGroupChatScreen(structureId: structureId);
-          },
-        );
-      },
-    ),

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -1501,6 +1501,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
             bulletColor: _tileRed,
           ),
           _sheetAction(
+            label: 'Messagerie interne MAM (groupe)',
+            onTap: () => context.go('/mam/messages'),
+            bulletColor: _tileRed,
+          ),
+          _sheetAction(
             label: 'Température frigo / congélateur + alertes',
             onTap: _showMAMFunctioning,
             bulletColor: _tileRed,

--- a/lib/screens/mam_group_chat_screen.dart
+++ b/lib/screens/mam_group_chat_screen.dart
@@ -1,6 +1,3 @@
-import 'dart:async';
-import 'dart:typed_data';
-
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -8,155 +5,343 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:file_picker/file_picker.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:mime/mime.dart';
+import 'package:url_launcher/url_launcher_string.dart';
 
 class MamGroupChatScreen extends StatefulWidget {
-  final String structureId;
-  const MamGroupChatScreen({Key? key, required this.structureId})
-      : super(key: key);
+  final String mamId;
+
+  const MamGroupChatScreen({Key? key, required this.mamId}) : super(key: key);
 
   @override
   State<MamGroupChatScreen> createState() => _MamGroupChatScreenState();
 }
 
 class _MamGroupChatScreenState extends State<MamGroupChatScreen> {
-  final _auth = FirebaseAuth.instance;
-  final _firestore = FirebaseFirestore.instance;
-  final TextEditingController _controller = TextEditingController();
-  bool _sending = false;
-  bool _uploading = false;
+  final FirebaseFirestore _firestore = FirebaseFirestore.instance;
+  final FirebaseAuth _auth = FirebaseAuth.instance;
+  final TextEditingController _messageController = TextEditingController();
+
+  late Future<Stream<QuerySnapshot>> _messagesStreamFuture;
+  bool _isSending = false;
+  bool _isUploadingFile = false;
+
+  static const Color _primaryBlue = Color(0xFF3D9DF2);
+  static const Color _bubbleGrey = Color(0xFFF4F6F8);
 
   @override
-  Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: AppBar(
-        title: const Text('Messagerie interne MAM'),
-        centerTitle: true,
-      ),
-      body: Column(
-        children: [
-          Expanded(
-            child: StreamBuilder<QuerySnapshot<Map<String, dynamic>>>(
-              stream: _firestore
-                  .collection('structures')
-                  .doc(widget.structureId)
-                  .collection('mam_chat')
-                  .doc('default')
-                  .collection('messages')
-                  .orderBy('timestamp', descending: true)
-                  .limit(200)
-                  .snapshots(),
-              builder: (context, snapshot) {
-                if (snapshot.connectionState == ConnectionState.waiting) {
-                  return const Center(child: CircularProgressIndicator());
-                }
-                final docs = snapshot.data?.docs ?? [];
-                return ListView.builder(
-                  reverse: true,
-                  itemCount: docs.length,
-                  itemBuilder: (context, index) {
-                    final data = docs[index].data();
-                    final isMe = (data['senderEmail'] ?? '')
-                            .toString()
-                            .toLowerCase() ==
-                        (_auth.currentUser?.email ?? '').toLowerCase();
-                    final ts = data['timestamp'];
-                    final time = ts is Timestamp
-                        ? DateFormat('dd/MM HH:mm').format(ts.toDate())
-                        : '';
-                    final type = (data['type'] ?? 'text').toString();
+  void initState() {
+    super.initState();
+    _messagesStreamFuture = _createMessagesStream();
+  }
 
-                    return Align(
-                      alignment:
-                          isMe ? Alignment.centerRight : Alignment.centerLeft,
-                      child: Container(
-                        margin:
-                            const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
-                        padding: const EdgeInsets.all(12),
-                        constraints: const BoxConstraints(maxWidth: 280),
-                        decoration: BoxDecoration(
-                          color: isMe
-                              ? const Color(0xFF3D9DF2).withOpacity(0.12)
-                              : Colors.grey.shade200,
-                          borderRadius: BorderRadius.circular(14),
-                        ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            if (!isMe)
-                              Text(
-                                (data['senderName'] ?? data['senderEmail'] ?? '')
-                                    .toString(),
-                                style: const TextStyle(
-                                    fontWeight: FontWeight.w600, fontSize: 12),
-                              ),
-                            if (type == 'file')
-                              _FileBubble(
-                                fileName: (data['fileName'] ?? '').toString(),
-                                url: (data['fileUrl'] ?? '').toString(),
-                              )
-                            else
-                              Text(
-                                (data['text'] ?? '').toString(),
-                                style: const TextStyle(fontSize: 15),
-                              ),
-                            const SizedBox(height: 6),
-                            Text(
-                              time,
-                              style: TextStyle(
-                                  fontSize: 11, color: Colors.grey.shade600),
-                            ),
-                          ],
-                        ),
-                      ),
-                    );
-                  },
-                );
-              },
+  @override
+  void dispose() {
+    _messageController.dispose();
+    super.dispose();
+  }
+
+  Future<Stream<QuerySnapshot>> _createMessagesStream() async {
+    final baseQuery = _firestore
+        .collection('exchanges')
+        .where('mamId', isEqualTo: widget.mamId);
+
+    try {
+      await baseQuery.orderBy('timestamp', descending: true).limit(1).get();
+      return baseQuery.orderBy('timestamp', descending: true).snapshots();
+    } on FirebaseException catch (e) {
+      if (e.code == 'failed-precondition') {
+        return baseQuery.snapshots();
+      }
+      rethrow;
+    }
+  }
+
+  Future<String> _getSenderDisplayName(User user) async {
+    final displayName = (user.displayName ?? '').trim();
+    if (displayName.isNotEmpty) {
+      return displayName;
+    }
+
+    final email = user.email?.toLowerCase();
+    if (email != null && email.isNotEmpty) {
+      final userDoc = await _firestore.collection('users').doc(email).get();
+      if (userDoc.exists) {
+        final data = userDoc.data();
+        final firstName = data?['firstName']?.toString().trim() ?? '';
+        final lastName = data?['lastName']?.toString().trim() ?? '';
+        final fullName = '$firstName $lastName'.trim();
+        if (fullName.isNotEmpty) {
+          return fullName;
+        }
+        final fallback = data?['fullName']?.toString().trim() ?? '';
+        if (fallback.isNotEmpty) {
+          return fallback;
+        }
+      }
+    }
+
+    return email ?? user.uid;
+  }
+
+  Future<void> _sendMessage() async {
+    final text = _messageController.text.trim();
+    if (text.isEmpty) return;
+
+    final user = _auth.currentUser;
+    if (user == null) return;
+
+    setState(() => _isSending = true);
+
+    try {
+      final senderName = await _getSenderDisplayName(user);
+      final senderFcmToken = await FirebaseMessaging.instance.getToken();
+
+      await _firestore.collection('exchanges').add({
+        'mamId': widget.mamId,
+        'senderId': user.uid,
+        'senderEmail': user.email?.toLowerCase(),
+        'senderName': senderName,
+        'senderType': 'mam_member',
+        'content': text,
+        'type': 'text',
+        'timestamp': FieldValue.serverTimestamp(),
+        'nonLu': true,
+        'senderFcmToken': senderFcmToken,
+      });
+
+      _messageController.clear();
+      FocusScope.of(context).unfocus();
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(content: Text("Erreur lors de l'envoi du message: $e")),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isSending = false);
+    }
+  }
+
+  Future<void> _pickAndSendFile() async {
+    final user = _auth.currentUser;
+    if (user == null || _isUploadingFile) return;
+
+    try {
+      setState(() => _isUploadingFile = true);
+
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.any,
+        allowMultiple: false,
+        withData: true,
+      );
+
+      if (result == null || result.files.isEmpty) {
+        setState(() => _isUploadingFile = false);
+        return;
+      }
+
+      final file = result.files.first;
+      final bytes = file.bytes;
+      if (bytes == null) {
+        throw Exception('Fichier non valide');
+      }
+
+      if (file.size > 10 * 1024 * 1024) {
+        throw Exception('Le fichier est trop volumineux (maximum 10MB)');
+      }
+
+      final mimeType = lookupMimeType(file.name) ?? 'application/octet-stream';
+      final timestamp = DateTime.now().millisecondsSinceEpoch.toString();
+      final storagePath =
+          'mam_group_messages/${widget.mamId}/$timestamp-${file.name}';
+      final storageRef = FirebaseStorage.instance.ref().child(storagePath);
+
+      final metadata = SettableMetadata(
+        contentType: mimeType,
+        customMetadata: {
+          'mamId': widget.mamId,
+          'senderId': user.uid,
+          'originalName': file.name,
+        },
+      );
+
+      await storageRef.putData(bytes, metadata);
+      final downloadUrl = await storageRef.getDownloadURL();
+
+      final senderName = await _getSenderDisplayName(user);
+      final senderFcmToken = await FirebaseMessaging.instance.getToken();
+
+      await _firestore.collection('exchanges').add({
+        'mamId': widget.mamId,
+        'senderId': user.uid,
+        'senderEmail': user.email?.toLowerCase(),
+        'senderName': senderName,
+        'senderType': 'mam_member',
+        'type': 'file',
+        'fileName': file.name,
+        'fileUrl': downloadUrl,
+        'fileType': mimeType,
+        'fileSize': file.size,
+        'timestamp': FieldValue.serverTimestamp(),
+        'nonLu': true,
+        'senderFcmToken': senderFcmToken,
+      });
+
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Fichier envoyé avec succès'),
+            backgroundColor: Colors.green,
+          ),
+        );
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              e.toString().contains('Exception:')
+                  ? e.toString().split('Exception: ').last
+                  : "Erreur lors de l'envoi du fichier",
             ),
           ),
-          SafeArea(
-            child: Container(
-              padding: const EdgeInsets.fromLTRB(12, 8, 12, 12),
-              child: Row(
-                children: [
-                  IconButton(
-                    onPressed: _uploading ? null : _pickAndSendFile,
-                    icon: _uploading
-                        ? const SizedBox(
-                            width: 20,
-                            height: 20,
-                            child: CircularProgressIndicator(strokeWidth: 2),
-                          )
-                        : const Icon(Icons.attach_file),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _isUploadingFile = false);
+    }
+  }
+
+  Widget _buildMessagesView() {
+    return FutureBuilder<Stream<QuerySnapshot>>(
+      future: _messagesStreamFuture,
+      builder: (context, streamSnapshot) {
+        if (streamSnapshot.connectionState == ConnectionState.waiting) {
+          return const Center(child: CircularProgressIndicator());
+        }
+        if (streamSnapshot.hasError) {
+          return const Center(
+            child: Text('Erreur de chargement des messages'),
+          );
+        }
+        if (!streamSnapshot.hasData) {
+          return const Center(child: Text('Aucun message'));
+        }
+
+        return StreamBuilder<QuerySnapshot>(
+          stream: streamSnapshot.data!,
+          builder: (context, snapshot) {
+            if (snapshot.hasError) {
+              return const Center(
+                child: Text('Erreur de chargement des messages'),
+              );
+            }
+            if (snapshot.connectionState == ConnectionState.waiting) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            final docs = snapshot.data?.docs ?? [];
+            if (docs.isEmpty) {
+              return const Center(
+                child: Padding(
+                  padding: EdgeInsets.all(24.0),
+                  child: Text(
+                    'Commencez la discussion avec votre équipe MAM.',
+                    textAlign: TextAlign.center,
                   ),
-                  Expanded(
-                    child: TextField(
-                      controller: _controller,
-                      textInputAction: TextInputAction.send,
-                      onSubmitted: (_) => _sendText(),
-                      decoration: const InputDecoration(
-                        hintText: 'Écrire un message...',
-                        border: OutlineInputBorder(
-                          borderRadius: BorderRadius.all(Radius.circular(14)),
+                ),
+              );
+            }
+
+            final messages = List<QueryDocumentSnapshot>.from(docs);
+            messages.sort((a, b) {
+              final aTs =
+                  (a.data() as Map<String, dynamic>)['timestamp'] as Timestamp?;
+              final bTs =
+                  (b.data() as Map<String, dynamic>)['timestamp'] as Timestamp?;
+              final aMillis = aTs?.millisecondsSinceEpoch ?? 0;
+              final bMillis = bTs?.millisecondsSinceEpoch ?? 0;
+              return bMillis.compareTo(aMillis);
+            });
+
+            final currentUserId = _auth.currentUser?.uid;
+
+            return ListView.builder(
+              reverse: true,
+              padding: const EdgeInsets.all(12),
+              itemCount: messages.length,
+              itemBuilder: (context, index) {
+                final data = messages[index].data() as Map<String, dynamic>;
+                final isMe = data['senderId'] == currentUserId;
+                return _buildMessageBubble(data, isMe);
+              },
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildMessageBubble(Map<String, dynamic> message, bool isMe) {
+    final type = (message['type'] ?? 'text').toString();
+    final timestamp = message['timestamp'] as Timestamp?;
+    final time = timestamp != null
+        ? DateFormat('dd/MM HH:mm').format(timestamp.toDate())
+        : '';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 6),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.end,
+        mainAxisAlignment:
+            isMe ? MainAxisAlignment.end : MainAxisAlignment.start,
+        children: [
+          if (!isMe)
+            Padding(
+              padding: const EdgeInsets.only(right: 8.0),
+              child: CircleAvatar(
+                radius: 18,
+                backgroundColor: _primaryBlue.withOpacity(0.15),
+                child: const Icon(Icons.person, color: _primaryBlue),
+              ),
+            ),
+          Flexible(
+            child: Container(
+              padding: const EdgeInsets.all(12),
+              decoration: BoxDecoration(
+                color: isMe ? _primaryBlue.withOpacity(0.1) : _bubbleGrey,
+                borderRadius: BorderRadius.circular(16),
+              ),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  if (!isMe)
+                    Padding(
+                      padding: const EdgeInsets.only(bottom: 4.0),
+                      child: Text(
+                        (message['senderName'] ?? message['senderEmail'] ?? '')
+                            .toString(),
+                        style: const TextStyle(
+                          fontWeight: FontWeight.w600,
+                          fontSize: 13,
                         ),
-                        contentPadding:
-                            EdgeInsets.symmetric(horizontal: 12, vertical: 10),
                       ),
                     ),
-                  ),
-                  const SizedBox(width: 8),
-                  ElevatedButton(
-                    onPressed: _sending ? null : _sendText,
-                    child: _sending
-                        ? const SizedBox(
-                            width: 16,
-                            height: 16,
-                            child: CircularProgressIndicator(
-                              strokeWidth: 2,
-                              color: Colors.white,
-                            ),
-                          )
-                        : const Text('Envoyer'),
+                  type == 'file'
+                      ? _buildFileMessage(message, isMe)
+                      : Text(
+                          (message['content'] ?? message['text'] ?? '')
+                              .toString(),
+                          style: const TextStyle(color: Colors.black87),
+                        ),
+                  const SizedBox(height: 6),
+                  Text(
+                    time,
+                    style: TextStyle(
+                      fontSize: 11,
+                      color: Colors.grey.shade600,
+                    ),
                   ),
                 ],
               ),
@@ -167,138 +352,163 @@ class _MamGroupChatScreenState extends State<MamGroupChatScreen> {
     );
   }
 
-  Future<void> _sendText() async {
-    final user = _auth.currentUser;
-    if (user == null) return;
-    final text = _controller.text.trim();
-    if (text.isEmpty) return;
-    setState(() => _sending = true);
-    try {
-      final fcmToken = await FirebaseMessaging.instance.getToken();
-      await _firestore
-          .collection('structures')
-          .doc(widget.structureId)
-          .collection('mam_chat')
-          .doc('default')
-          .collection('messages')
-          .add({
-        'type': 'text',
-        'text': text,
-        'senderId': user.uid,
-        'senderEmail': (user.email ?? '').toLowerCase(),
-        'senderName': user.displayName ?? '',
-        'timestamp': FieldValue.serverTimestamp(),
-        'structureId': widget.structureId,
-        'senderFcmToken': fcmToken ?? '',
-        'notificationSent': false,
-      });
-      _controller.clear();
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Erreur envoi: $e')),
-        );
+  Widget _buildFileMessage(Map<String, dynamic> message, bool isMe) {
+    final fileType = message['fileType']?.toString() ?? '';
+    final isImage = fileType.startsWith('image/');
+    final fileName = (message['fileName'] ?? 'Fichier').toString();
+
+    Future<void> openFile() async {
+      try {
+        final fileUrl = message['fileUrl']?.toString();
+        if (fileUrl == null || fileUrl.isEmpty) {
+          throw 'URL du fichier non disponible';
+        }
+
+        if (await canLaunchUrlString(fileUrl)) {
+          await launchUrlString(fileUrl);
+        } else {
+          throw 'Impossible d\'ouvrir le fichier';
+        }
+      } catch (e) {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Erreur: $e')),
+          );
+        }
       }
-    } finally {
-      if (mounted) setState(() => _sending = false);
     }
-  }
 
-  Future<void> _pickAndSendFile() async {
-    final user = _auth.currentUser;
-    if (user == null) return;
-    try {
-      setState(() => _uploading = true);
-      final result = await FilePicker.platform.pickFiles(
-        allowMultiple: false,
-        withData: true,
-        type: FileType.any,
-      );
-      if (result == null || result.files.isEmpty) {
-        setState(() => _uploading = false);
-        return;
-      }
-      final file = result.files.first;
-      final bytes = file.bytes as Uint8List?;
-      if (bytes == null) throw Exception('Fichier non valide');
-      if (file.size > 15 * 1024 * 1024) {
-        throw Exception('Fichier trop volumineux (max 15 Mo)');
-      }
-
-      final messageRef = _firestore
-          .collection('structures')
-          .doc(widget.structureId)
-          .collection('mam_chat')
-          .doc('default')
-          .collection('messages')
-          .doc();
-
-      final storageRef = FirebaseStorage.instance
-          .ref()
-          .child('mam_chats/${widget.structureId}/${messageRef.id}/${file.name}');
-      await storageRef.putData(bytes, SettableMetadata(contentType: file.extension));
-      final url = await storageRef.getDownloadURL();
-
-      final fcmToken = await FirebaseMessaging.instance.getToken();
-      await messageRef.set({
-        'type': 'file',
-        'fileName': file.name,
-        'fileUrl': url,
-        'senderId': user.uid,
-        'senderEmail': (user.email ?? '').toLowerCase(),
-        'senderName': user.displayName ?? '',
-        'timestamp': FieldValue.serverTimestamp(),
-        'structureId': widget.structureId,
-        'senderFcmToken': fcmToken ?? '',
-        'notificationSent': false,
-      });
-    } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Erreur envoi fichier: $e')),
-        );
-      }
-    } finally {
-      if (mounted) setState(() => _uploading = false);
-    }
-  }
-}
-
-class _FileBubble extends StatelessWidget {
-  final String fileName;
-  final String url;
-  const _FileBubble({required this.fileName, required this.url});
-
-  @override
-  Widget build(BuildContext context) {
-    return Row(
-      mainAxisSize: MainAxisSize.min,
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        const Icon(Icons.insert_drive_file, size: 18),
-        const SizedBox(width: 6),
-        Flexible(
-          child: Text(
-            fileName,
-            style: const TextStyle(
-              decoration: TextDecoration.underline,
+        InkWell(
+          onTap: openFile,
+          borderRadius: BorderRadius.circular(8),
+          child: Padding(
+            padding: const EdgeInsets.all(4.0),
+            child: Row(
+              children: [
+                Icon(
+                  isImage ? Icons.image : Icons.insert_drive_file,
+                  color: isMe ? _primaryBlue : Colors.black54,
+                ),
+                const SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    fileName,
+                    style: TextStyle(
+                      color: isMe ? _primaryBlue : Colors.black87,
+                      decoration: TextDecoration.underline,
+                    ),
+                    maxLines: 1,
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+                const SizedBox(width: 8),
+                Icon(Icons.open_in_new, size: 18, color: Colors.grey.shade600),
+              ],
             ),
-            overflow: TextOverflow.ellipsis,
           ),
         ),
-        const SizedBox(width: 8),
-        IconButton(
-          icon: const Icon(Icons.open_in_new, size: 18),
-          onPressed: () async {
-            // Simple: confier au système via URL
-            // Le projet dispose déjà d\'ouverture d\'URL ailleurs, on reste minimal ici
-            // ignore: use_build_context_synchronously
-            ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Ouverture du fichier...')),
-            );
-          },
-        )
+        if (isImage && message['fileUrl'] != null) ...[
+          const SizedBox(height: 8),
+          ClipRRect(
+            borderRadius: BorderRadius.circular(8),
+            child: Image.network(
+              message['fileUrl'],
+              width: 220,
+              height: 220,
+              fit: BoxFit.cover,
+              errorBuilder: (context, error, stackTrace) {
+                return Container(
+                  width: 220,
+                  height: 160,
+                  color: Colors.grey.shade200,
+                  alignment: Alignment.center,
+                  child: const Icon(Icons.broken_image, color: Colors.grey),
+                );
+              },
+            ),
+          ),
+        ],
       ],
     );
   }
-}
 
+  Widget _buildComposer() {
+    return Container(
+      color: Colors.white,
+      padding: EdgeInsets.fromLTRB(
+        12,
+        8,
+        12,
+        MediaQuery.of(context).padding.bottom + 8,
+      ),
+      child: SafeArea(
+        top: false,
+        left: false,
+        right: false,
+        child: Row(
+          children: [
+            IconButton(
+              onPressed: _isUploadingFile ? null : _pickAndSendFile,
+              icon: _isUploadingFile
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(strokeWidth: 2),
+                    )
+                  : const Icon(Icons.attach_file),
+            ),
+            Expanded(
+              child: TextField(
+                controller: _messageController,
+                textInputAction: TextInputAction.send,
+                onSubmitted: (_) => _sendMessage(),
+                decoration: const InputDecoration(
+                  hintText: 'Écrire un message…',
+                  border: OutlineInputBorder(
+                    borderRadius: BorderRadius.all(Radius.circular(20)),
+                  ),
+                  isDense: true,
+                  contentPadding:
+                      EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                ),
+              ),
+            ),
+            const SizedBox(width: 8),
+            ElevatedButton(
+              onPressed: _isSending ? null : _sendMessage,
+              child: _isSending
+                  ? const SizedBox(
+                      width: 16,
+                      height: 16,
+                      child: CircularProgressIndicator(
+                        strokeWidth: 2,
+                        color: Colors.white,
+                      ),
+                    )
+                  : const Text('Envoyer'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Messagerie interne MAM (groupe)'),
+        centerTitle: true,
+      ),
+      body: Column(
+        children: [
+          Expanded(child: _buildMessagesView()),
+          _buildComposer(),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add a dedicated MamGroupChatScreen that loads exchanges filtered by mamId and supports text plus file attachments via Firebase Storage
- register the new screen on the /mam/messages route and expose it from the daily operations sheet in the dashboard

## Testing
- flutter analyze *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c92f87f50c832e897e7b3874c63c9e