### PR TITLE
Add MAM group chat access from daily operations

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -10,6 +10,7 @@ import 'package:poppins_app/screens/child_profile_details_screen.dart';
 import 'package:poppins_app/screens/photo_management_screen.dart';
 import 'package:poppins_app/screens/child_removal_screen.dart';
 import 'package:poppins_app/screens/mam_member_add_screen.dart';
+import 'package:poppins_app/screens/mam_group_chat_screen.dart';
 import 'package:poppins_app/screens/mam_member_removal_screen.dart';
 import 'package:poppins_app/screens/fridge_temperature_screen.dart';
 import 'package:poppins_app/screens/planning_screen.dart';
@@ -1450,6 +1451,11 @@ class _DashboardScreenState extends State<DashboardScreen> {
             bulletColor: _tileRed,
           ),
           _sheetAction(
+            label: 'Messagerie interne MAM',
+            onTap: _openMamGroupChat,
+            bulletColor: _tileRed,
+          ),
+          _sheetAction(
             label: 'Température frigo / congélateur + alertes',
             onTap: _showMAMFunctioning,
             bulletColor: _tileRed,
@@ -1482,6 +1488,21 @@ class _DashboardScreenState extends State<DashboardScreen> {
         ],
       );
     }
+  }
+
+  Future<void> _openMamGroupChat() async {
+    final structureId = await _getStructureId();
+    if (!mounted) return;
+    if (structureId.isEmpty) {
+      return;
+    }
+
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => MamGroupChatScreen(structureId: structureId),
+      ),
+    );
   }
 
   void _openChildrenParents() {


### PR DESCRIPTION
## Summary
- import the MAM group chat screen into the dashboard
- add a helper that opens the MAM group chat once the structure id is available
- expose the new internal messaging entry in the MAM daily operations sheet

## Testing
- flutter analyze *(fails: flutter not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cac0cdd7a0832eba2eb3065bf821ed